### PR TITLE
Generalize IO to polymorphic effect

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -78,7 +78,7 @@ object Converter extends IOApp {
         (f - 32.0) * (5.0 / 9.0)
 
       reader
-        .withBlocker(blocker)
+        .shifting(blocker)
         .read(Paths.get("testdata/fahrenheit.txt"))
         .through(parser.parse)
         .filter(r => !r("temp").isEmpty)
@@ -460,7 +460,7 @@ object Converter extends IOApp {
       val dst = Paths.get("testdata/celsius.txt")
 
       reader
-        .withBlocker(blocker)
+        .shifting(blocker)
         .read(src)
         .through(parser.parse)
         .filter(r => !r("temp").isEmpty)

--- a/roadmap.md
+++ b/roadmap.md
@@ -5,7 +5,6 @@ The library provides already a practical solution although with reasonable featu
 There are however many features which should made it even better.  
 Planned development includes:
 * Parsing chunks instead of single elements.
-* Generalize IO to polymorphic effect with tagless-final.
 * Providing logging.
 The above topics should conclude version 1.0
 

--- a/src/main/scala/info/fingo/spata/CSVConfig.scala
+++ b/src/main/scala/info/fingo/spata/CSVConfig.scala
@@ -5,10 +5,12 @@
  */
 package info.fingo.spata
 
+import fs2.RaiseThrowable
+
 /** CSV configuration used for creating [[CSVParser]].
   *
   * This config may be used as a builder to create a parser:
-  * {{{ val parser = CSVConfig.fieldSizeLimit(1000).noHeader().get }}}
+  * {{{ val parser = CSVConfig.fieldSizeLimit(1000).noHeader().get[IO] }}}
   *
   * Field delimiter is `','` by default.
   *
@@ -70,6 +72,11 @@ case class CSVConfig private[spata] (
   /** Remap selected fields names. */
   def mapHeader(mh: S2S): CSVConfig = this.copy(mapHeader = mh)
 
-  /** Creates [[CSVParser]] from this config. */
-  def get: CSVParser = new CSVParser(this)
+  /** Creates [[CSVParser]] from this config.
+    *
+    * @tparam F the effect type, with a type class providing support for raising and handling errors
+    * (typically [[cats.effect.IO]])
+    * @return parser configured according to provided settings
+    */
+  def get[F[_]: RaiseThrowable]: CSVParser[F] = new CSVParser(this)
 }

--- a/src/main/scala/info/fingo/spata/CSVParser.scala
+++ b/src/main/scala/info/fingo/spata/CSVParser.scala
@@ -6,8 +6,8 @@
 package info.fingo.spata
 
 import scala.util.Try
-import cats.effect.{Concurrent, IO}
-import fs2.{Pipe, Pull, Stream}
+import cats.effect.{Concurrent, Sync}
+import fs2.{Pipe, Pull, RaiseThrowable, Stream}
 import info.fingo.spata.parser.{CharParser, FieldParser, ParsingErrorCode, RecordParser}
 import info.fingo.spata.parser.RecordParser.ParsingResult
 import info.fingo.spata.CSVParser.CSVCallback
@@ -18,27 +18,35 @@ import info.fingo.spata.CSVParser.CSVCallback
   *
   * The parser may be created by providing full configuration with [[CSVConfig]]
   * or through a helper [[CSVParser.config]] function from companion object, e.g.:
-  * {{{ val parser = CSVParser.config.fieldDelimiter(';').get }}}
+  * {{{ val parser = CSVParser.config.fieldDelimiter(';').get[IO] }}}
   *
-  * Actual parsing is done through one of the 3 groups methods:
+  * Actual parsing is done through one of the 3 groups of methods:
   *  - [[parse]] to transform a stream of characters into records and process data in a functional way,
   *    which is the recommended approach
-  *  - [[get(stream:fs2\.Stream[cats\.effect\.IO,Char])* get]] to fetch whole source data at once into a list
+  *  - [[get(stream:fs2\.Stream[F,Char])* get]] to fetch whole source data at once into a list
   *  - [[process]] to deal with individual records through a callback function.
   *
   * This parser is normally used with stream fetching data from some external source,
-  * so its computations are wrapped into [[cats.effect.IO]] for deferred evaluation.
-  * To trigger evaluation one of the `unsafe` operations on `IO`
-  * (e.g. [[cats.effect.IO.unsafeRunSync]]) has to be called.
+  * so its computations are wrapped for deferred evaluation into an effect `F`, e.g. [[cats.effect.IO]].
+  * Basic parsing does not impose any special requirements on `F`, except its support for raising and handling errors,
+  * which requires implicit instance of [[fs2.RaiseThrowable]], meaning `ApplicativeError[F, Throwable]`
+  * or `MonadError[F, Throwable]`.
+  * However convenience methods for loading data into list or processing through callbacks
+  * require more complex type classes.
   *
-  * No method in this class does context shift and by default they execute synchronously on current thread.
+  * To trigger evaluation, one of the `unsafe` operations on `F` has to be called.
+  * Their exact form depends on actual effect in use (e.g. [[cats.effect.IO.unsafeRunSync]]).
+  *
+  * No method in this class does context (thread) shift and by default they execute synchronously on current thread.
   * Concurrency or asynchronous execution may be introduced through various [[fs2.Stream]] methods.
   * There is also supporting class [[CSVParser#Async]] available, which provides method for asynchronous callbacks.
   *
   * @constructor Creates parser with provided configuration.
   * @param config the configuration for CSV parsing (delimiters, header presence etc.)
+  * @tparam F the effect type, with a type class providing support for raising and handling errors
+  * (typically [[cats.effect.IO]])
   */
-class CSVParser(config: CSVConfig) {
+class CSVParser[F[_]: RaiseThrowable](config: CSVConfig) {
 
   /** Transforms into records stream of characters representing CSV data.
     * This function is intended to be used with [[fs2.Stream.through]].
@@ -46,7 +54,7 @@ class CSVParser(config: CSVConfig) {
     *
     * Processing of data sources may be achieved by combining this function with [[io.reader]], e.g.:
     * {{{
-    * val parser = CSVParser()
+    * val parser = CSVParser[IO]()
     * val stream: Stream[IO, CSVRecord] = Stream
     *   .bracket(IO { Source.fromFile("input.csv") })(source => IO { source.close() })
     *   .flatMap(reader(_))
@@ -60,24 +68,24 @@ class CSVParser(config: CSVConfig) {
     *
     * @return a pipe to converter [[scala.Char]]s into [[CSVRecord]]s
     */
-  def parse: Pipe[IO, Char, CSVRecord] = (in: Stream[IO, Char]) => {
-    val cp = new CharParser(config.fieldDelimiter, config.recordDelimiter, config.quoteMark)
-    val fp = new FieldParser(config.fieldSizeLimit)
-    val rp = new RecordParser()
+  def parse: Pipe[F, Char, CSVRecord] = (in: Stream[F, Char]) => {
+    val cp = new CharParser[F](config.fieldDelimiter, config.recordDelimiter, config.quoteMark)
+    val fp = new FieldParser[F](config.fieldSizeLimit)
+    val rp = new RecordParser[F]()
     val stream = in.through(cp.toCharResults).through(fp.toFields).through(rp.toRecords)
     val pull = if (config.hasHeader) contentWithHeader(stream) else contentWithoutHeader(stream)
     pull.stream.rethrow.flatMap(_.toRecords)
   }
 
   /* Splits source data into header and actual content. */
-  private def contentWithHeader(stream: Stream[IO, ParsingResult]) =
+  private def contentWithHeader(stream: Stream[F, ParsingResult]) =
     stream.pull.uncons1.flatMap {
       case Some((h, t)) => Pull.output1(CSVContent(h, t, config.mapHeader))
-      case None => Pull.raiseError[IO](new CSVStructureException(ParsingErrorCode.MissingHeader, 1, 0))
+      case None => Pull.raiseError[F](new CSVStructureException(ParsingErrorCode.MissingHeader, 1, 0))
     }
 
   /* Adds numeric header to source data - provides record size to construct it. */
-  private def contentWithoutHeader(stream: Stream[IO, ParsingResult]) =
+  private def contentWithoutHeader(stream: Stream[F, ParsingResult]) =
     stream.pull.peek1.flatMap {
       case Some((h, s)) => Pull.output1(CSVContent(h.fieldNum, s, config.mapHeader))
       case None => Pull.output1(CSVContent(0, stream, config.mapHeader))
@@ -88,11 +96,12 @@ class CSVParser(config: CSVConfig) {
     * This function should be used only for small amounts of source data to avoid memory overflow.
     *
     * @param stream the source stream containing CSV content
+    * @param F a type class (monad) providing suspended execution
     * @return the list of records
     * @throws CSVStructureException in case of flawed CSV structure
     */
   @throws[CSVStructureException]("in case of flawed CSV structure")
-  def get(stream: Stream[IO, Char]): IO[List[CSVRecord]] = get(stream, None)
+  def get(stream: Stream[F, Char])(implicit F: Sync[F]): F[List[CSVRecord]] = get(stream, None)
 
   /** Fetches requested number of CSV records into a list.
     *
@@ -102,14 +111,16 @@ class CSVParser(config: CSVConfig) {
     *
     * @param stream the source stream containing CSV content
     * @param limit the number of records to get
+    * @param F a type class (monad) providing suspended execution
     * @return the list of records
     * @throws CSVStructureException in case of flawed CSV structure
     */
   @throws[CSVStructureException]("in case of flawed CSV structure")
-  def get(stream: Stream[IO, Char], limit: Long): IO[List[CSVRecord]] = get(stream, Some(limit))
+  def get(stream: Stream[F, Char], limit: Long)(implicit F: Sync[F]): F[List[CSVRecord]] =
+    get(stream, Some(limit))
 
   /* Loads all or provided number of records into a list. */
-  private def get(stream: Stream[IO, Char], limit: Option[Long]): IO[List[CSVRecord]] = {
+  private def get(stream: Stream[F, Char], limit: Option[Long])(implicit F: Sync[F]): F[List[CSVRecord]] = {
     val s = stream.through(parse)
     val limited = limit match {
       case Some(l) => s.take(l)
@@ -124,25 +135,26 @@ class CSVParser(config: CSVConfig) {
     * @param stream the source stream containing CSV content
     * @param cb the callback function to operate on each CSV record and produce some side effect.
     * It should return `true` to continue the process with next record or `false` to stop processing the source.
-    * @return
+    * @param F a type class (monad) providing suspended execution
+    * @return unit effect, used as a handle to trigger evaluation
     * @throws CSVException in case of flawed CSV structure or field parsing errors
     */
   @throws[CSVException]("in case of flawed CSV structure or field parsing errors")
-  def process(stream: Stream[IO, Char])(cb: CSVCallback): IO[Unit] = {
+  def process(stream: Stream[F, Char])(cb: CSVCallback)(implicit F: Sync[F]): F[Unit] = {
     val effect = evalCallback(cb)
     stream.through(parse).through(effect).compile.drain
   }
 
-  /* Callback function wrapper to enclose it in IO effect and letting the stream to evaluate it when run. */
-  private def evalCallback(cb: CSVCallback): Pipe[IO, CSVRecord, Boolean] =
-    _.evalMap(pr => IO.delay(cb(pr))).takeWhile(_ == true)
+  /* Callback function wrapper to enclose it in effect F and letting the stream to evaluate it when run. */
+  private def evalCallback(cb: CSVCallback)(implicit F: Sync[F]): Pipe[F, CSVRecord, Boolean] =
+    _.evalMap(pr => F.delay(cb(pr))).takeWhile(_ == true)
 
   /** Provides access to asynchronous parsing method.
     *
-    * @param cc implicit instance of type class to provide support for concurrency
+    * @param F type class (monad) providing support for concurrency
     * @return helper class with asynchronous method
     */
-  def async(implicit cc: Concurrent[IO]): CSVParser.Async = new CSVParser.Async(this)(cc)
+  def async(implicit F: Concurrent[F]): CSVParser.Async[F] = new CSVParser.Async(this)(F)
 }
 
 /** [[CSVParser]] companion object with types definitions and convenience methods to create parsers. */
@@ -151,8 +163,13 @@ object CSVParser {
   /** Callback function type. */
   type CSVCallback = CSVRecord => Boolean
 
-  /** Creates a [[CSVParser]] with default configuration, as defined in RFC 4180. */
-  def apply(): CSVParser = new CSVParser(config)
+  /** Creates a [[CSVParser]] with default configuration, as defined in RFC 4180.
+    *
+    * @tparam F the effect type, with a type class providing support for raising and handling errors
+    * (typically [[cats.effect.IO]])
+    * @return new parser
+    */
+  def apply[F[_]: RaiseThrowable](): CSVParser[F] = new CSVParser(config)
 
   /** Provides default configuration, as defined in RFC 4180. */
   def config: CSVConfig = CSVConfig()
@@ -160,34 +177,34 @@ object CSVParser {
   /** [[CSVParser]] helper with asynchronous parsing method.
     *
     * @param parser the regular parser
-    * @param cc implicit instance of type class to provide support for concurrency
+    * @tparam F the effect type, with type class providing support for concurrency (typically [[cats.effect.IO]])
     */
-  final class Async private[CSVParser] (parser: CSVParser)(implicit cc: Concurrent[IO]) {
+  final class Async[F[_]: Concurrent] private[CSVParser] (parser: CSVParser[F]) {
 
     /** Processes each CSV record with provided callback functions to execute some side effects.
       * Stops processing input as soon as the callback function returns false, stream is exhausted or exception thrown.
       *
       * This function process the callbacks asynchronously while retaining order of handled data.
-      * The callback are run concurrently according to `maxConcurrent` parameter.
+      * The callbacks are run concurrently according to `maxConcurrent` parameter.
       *
-      * Processing success or failure may be checked by examining by callback to [[cats.effect.IO.unsafeRunAsync]]
-      * or handling error with [[cats.effect.IO.handleErrorWith]].
+      * Processing success or failure may be checked by examining by callback to method triggering effect evaluation
+      * (e.g. [[cats.effect.IO.unsafeRunAsync]]) or handling error (e.g. with [[cats.effect.IO.handleErrorWith]]).
       *
       * @param stream the source stream containing CSV content
       * @param maxConcurrent maximum number of concurrently evaluated effects
       * @param cb the callback function to operate on each CSV record and produce some side effect.
       * It should return `true` to continue with next record or `false` to stop processing the source.
-      * @return
+      * @return unit effect, used as a handle to trigger evaluation
       */
-    def process(stream: Stream[IO, Char], maxConcurrent: Int = 1)(cb: CSVCallback): IO[Unit] = {
+    def process(stream: Stream[F, Char], maxConcurrent: Int = 1)(cb: CSVCallback): F[Unit] = {
       val effect = evalCallback(maxConcurrent)(cb)
       stream.through(parser.parse).through(effect).compile.drain
     }
 
-    /* Callback function wrapper to enclose it in IO effect and letting the stream to evaluate it asynchronously when run. */
-    private def evalCallback(maxConcurrent: Int)(cb: CSVCallback): Pipe[IO, CSVRecord, Boolean] =
+    /* Callback function wrapper to enclose it in effect F and letting the stream to evaluate it asynchronously when run. */
+    private def evalCallback(maxConcurrent: Int)(cb: CSVCallback): Pipe[F, CSVRecord, Boolean] =
       _.mapAsync(maxConcurrent) { pr =>
-        IO.async[Boolean] { call =>
+        implicitly[Concurrent[F]].async[Boolean] { call =>
           val result = Try(cb(pr)).toEither
           call(result)
         }

--- a/src/main/scala/info/fingo/spata/CSVParser.scala
+++ b/src/main/scala/info/fingo/spata/CSVParser.scala
@@ -204,7 +204,7 @@ object CSVParser {
     /* Callback function wrapper to enclose it in effect F and letting the stream to evaluate it asynchronously when run. */
     private def evalCallback(maxConcurrent: Int)(cb: CSVCallback): Pipe[F, CSVRecord, Boolean] =
       _.mapAsync(maxConcurrent) { pr =>
-        implicitly[Concurrent[F]].async[Boolean] { call =>
+        Concurrent[F].async[Boolean] { call =>
           val result = Try(cb(pr)).toEither
           call(result)
         }

--- a/src/main/scala/info/fingo/spata/io/reader.scala
+++ b/src/main/scala/info/fingo/spata/io/reader.scala
@@ -196,9 +196,9 @@ object reader {
     /** @inheritdoc */
     def read(path: Path)(implicit codec: Codec): Stream[F, Char] =
       Stream
-        .bracket(implicitly[Sync[F]].delay {
+        .bracket(Sync[F].delay {
           Source.fromInputStream(Files.newInputStream(path, StandardOpenOption.READ))
-        })(source => implicitly[Sync[F]].delay { source.close() })
+        })(source => Sync[F].delay { source.close() })
         .flatMap(read)
   }
 
@@ -236,7 +236,7 @@ object reader {
       for {
         blocker <- Stream.resource(br)
         char <- io
-          .readInputStream(implicitly[Sync[F]].delay(is), blockSize, blocker, autoClose)
+          .readInputStream(Sync[F].delay(is), blockSize, blocker, autoClose)
           .through(byte2char)
       } yield char
 
@@ -258,7 +258,7 @@ object reader {
 
     /* Wrap provided blocker in dummy-resource or get real resource with new blocker. */
     private def br =
-      blocker.map(b => Resource(implicitly[Sync[F]].delay((b, implicitly[Sync[F]].unit)))).getOrElse(Blocker[F])
+      blocker.map(b => Resource(Sync[F].delay((b, Sync[F].unit)))).getOrElse(Blocker[F])
 
     private def byte2char(implicit codec: Codec): Pipe[F, Byte, Char] =
       _.through(decode(codec)).through(reader.skipBom)

--- a/src/main/scala/info/fingo/spata/parser/CharParser.scala
+++ b/src/main/scala/info/fingo/spata/parser/CharParser.scala
@@ -5,22 +5,21 @@
  */
 package info.fingo.spata.parser
 
-import cats.effect.IO
 import fs2.{Pipe, Pull, Stream}
 import ParsingErrorCode._
 
 /* A finite-state transducer to converter plain source characters into context-dependent symbols,
  * taking into consideration special meaning of some characters (e.g. separators), quoting and escaping.
  */
-private[spata] class CharParser(fieldDelimiter: Char, recordDelimiter: Char, quote: Char) {
+private[spata] class CharParser[F[_]](fieldDelimiter: Char, recordDelimiter: Char, quote: Char) {
   import CharParser._
   import CharParser.CharPosition._
 
   /* Transforms plain characters into context-dependent symbols by providing FS2 pipe. */
-  def toCharResults: Pipe[IO, Char, CharResult] = toCharResults(CharState(Left(STX), Start))
+  def toCharResults: Pipe[F, Char, CharResult] = toCharResults(CharState(Left(STX), Start))
 
-  private def toCharResults(state: CharState): Pipe[IO, Char, CharResult] = {
-    def loop(chars: Stream[IO, Char], state: CharState): Pull[IO, CharResult, Unit] =
+  private def toCharResults(state: CharState): Pipe[F, Char, CharResult] = {
+    def loop(chars: Stream[F, Char], state: CharState): Pull[F, CharResult, Unit] =
       chars.pull.uncons1.flatMap {
         case Some((h, t)) =>
           parseChar(h, state) match {

--- a/src/main/scala/info/fingo/spata/parser/FieldParser.scala
+++ b/src/main/scala/info/fingo/spata/parser/FieldParser.scala
@@ -5,27 +5,26 @@
  */
 package info.fingo.spata.parser
 
-import cats.effect.IO
 import fs2.{Pipe, Pull, Stream}
 import ParsingErrorCode._
 
 /* Converter from character symbols to CSV fields.
  * This class tracks source position while consuming symbols to report it precisely, especially in case of failure.
  */
-private[spata] class FieldParser(fieldSizeLimit: Option[Int]) {
+private[spata] class FieldParser[F[_]](fieldSizeLimit: Option[Int]) {
   import FieldParser._
   import CharParser._
   import CharParser.CharPosition._
 
   /* Transforms stream of character symbols into fields by providing FS2 pipe. */
-  def toFields: Pipe[IO, CharResult, FieldResult] = {
+  def toFields: Pipe[F, CharResult, FieldResult] = {
 
     def loop(
-      chars: Stream[IO, CharResult],
+      chars: Stream[F, CharResult],
       sb: StringBuilder,
       counters: Location,
       lc: LocalCounts
-    ): Pull[IO, FieldResult, Unit] =
+    ): Pull[F, FieldResult, Unit] =
       if (fieldTooLong(lc))
         Pull.output1(fail(FieldTooLong, counters, lc)) >> Pull.done
       else

--- a/src/main/scala/info/fingo/spata/parser/RecordParser.scala
+++ b/src/main/scala/info/fingo/spata/parser/RecordParser.scala
@@ -6,19 +6,18 @@
 package info.fingo.spata.parser
 
 import scala.collection.immutable.VectorBuilder
-import cats.effect.IO
 import fs2.{Pipe, Pull, Stream}
 
 /* Converter from CSV fields to records. */
-private[spata] class RecordParser {
+private[spata] class RecordParser[F[_]] {
 
   import RecordParser._
   import FieldParser._
 
   /* Transforms stream of fields into records by providing FS2 pipe. */
-  def toRecords: Pipe[IO, FieldResult, ParsingResult] = {
+  def toRecords: Pipe[F, FieldResult, ParsingResult] = {
 
-    def loop(fields: Stream[IO, FieldResult], vb: VectorBuilder[String], recNum: Int): Pull[IO, ParsingResult, Unit] =
+    def loop(fields: Stream[F, FieldResult], vb: VectorBuilder[String], recNum: Int): Pull[F, ParsingResult, Unit] =
       fields.pull.uncons1.flatMap {
         case Some((h, t)) =>
           h match {

--- a/src/test/scala/info/fingo/spata/CSVConfigTS.scala
+++ b/src/test/scala/info/fingo/spata/CSVConfigTS.scala
@@ -22,7 +22,7 @@ class CSVConfigTS extends AnyFunSuite {
     val rs = 0x1E.toChar
     val content = s"'value 1A'|'value ''1B'$rs'value 2A'|'value ''2B'"
     val config = CSVConfig().fieldDelimiter('|').quoteMark('\'').recordDelimiter(rs).noHeader()
-    val data = reader(Source.fromString(content))
+    val data = reader[IO].read(Source.fromString(content))
     val parser = config.get[IO]
     val result = parser.get(data).unsafeRunSync()
     assert(result.length == 2)

--- a/src/test/scala/info/fingo/spata/CSVConfigTS.scala
+++ b/src/test/scala/info/fingo/spata/CSVConfigTS.scala
@@ -5,10 +5,10 @@
  */
 package info.fingo.spata
 
-import info.fingo.spata.io.reader
-
-import scala.io.Source
 import org.scalatest.funsuite.AnyFunSuite
+import scala.io.Source
+import cats.effect.IO
+import info.fingo.spata.io.reader
 
 class CSVConfigTS extends AnyFunSuite {
 
@@ -23,7 +23,7 @@ class CSVConfigTS extends AnyFunSuite {
     val content = s"'value 1A'|'value ''1B'$rs'value 2A'|'value ''2B'"
     val config = CSVConfig().fieldDelimiter('|').quoteMark('\'').recordDelimiter(rs).noHeader()
     val data = reader(Source.fromString(content))
-    val parser = config.get
+    val parser = config.get[IO]
     val result = parser.get(data).unsafeRunSync()
     assert(result.length == 2)
     assert(result.head.size == 2)

--- a/src/test/scala/info/fingo/spata/CSVParserPTS.scala
+++ b/src/test/scala/info/fingo/spata/CSVParserPTS.scala
@@ -25,12 +25,13 @@ object CSVParserPTS extends Bench.LocalTime {
   performance.of("parser").config(exec.maxWarmupRuns -> 1, exec.benchRuns -> 3) in {
     measure.method("parse_gen") in {
       using(amounts) in { amount =>
-        reader(new TestSource(separator, amount)).through(parser.parse).compile.drain.unsafeRunSync()
+        reader[IO].read(new TestSource(separator, amount)).through(parser.parse).compile.drain.unsafeRunSync()
       }
     }
     measure.method("parse_and_convert_gen") in {
       using(amounts) in { amount =>
-        reader(new TestSource(separator, amount))
+        reader[IO]
+          .read(new TestSource(separator, amount))
           .through(parser.parse)
           .map(_.to[(Double, Double, Double, Double, Double, Double, Double, Double, Double, String)])
           .compile
@@ -40,7 +41,8 @@ object CSVParserPTS extends Bench.LocalTime {
     }
     measure.method("parse_and_convert_file") in {
       using(Gen.unit("file")) in { _ =>
-        reader(path)
+        reader[IO]
+          .read(path)
           .through(parser.parse)
           .map(_.to[(Int, LocalDate, Int, Int, String, String, String, String, String, String)])
           .compile

--- a/src/test/scala/info/fingo/spata/CSVParserPTS.scala
+++ b/src/test/scala/info/fingo/spata/CSVParserPTS.scala
@@ -8,6 +8,7 @@ package info.fingo.spata
 import java.nio.file.Paths
 import java.time.LocalDate
 import scala.io.Source
+import cats.effect.IO
 import info.fingo.spata.io.reader
 import org.scalameter.{Bench, Gen}
 import org.scalameter.Key.exec
@@ -19,7 +20,7 @@ object CSVParserPTS extends Bench.LocalTime {
 
   private val separator = ','
   private val path = Paths.get(getClass.getClassLoader.getResource("mars-weather.csv").toURI)
-  private val parser = CSVParser.config.fieldDelimiter(separator).get
+  private val parser = CSVParser.config.fieldDelimiter(separator).get[IO]
 
   performance.of("parser").config(exec.maxWarmupRuns -> 1, exec.benchRuns -> 3) in {
     measure.method("parse_gen") in {

--- a/src/test/scala/info/fingo/spata/CSVParserTS.scala
+++ b/src/test/scala/info/fingo/spata/CSVParserTS.scala
@@ -107,7 +107,7 @@ class CSVParserTS extends AnyFunSuite with TableDrivenPropertyChecks {
       ) =>
         forAll(separators) { separator =>
           val parser = CSVParser.config.fieldDelimiter(separator).fieldSizeLimit(maxFieldSize).get[IO]
-          val input = reader(generateErroneousCSV(testCase, separator))
+          val input = reader[IO].read(generateErroneousCSV(testCase, separator))
           val stream = input.through(parser.parse)
           val eh: StreamErrorHandler =
             ex => assertError(ex, errorCode, line, col, row, field)(Stream.emit(()))
@@ -128,7 +128,7 @@ class CSVParserTS extends AnyFunSuite with TableDrivenPropertyChecks {
       ) =>
         forAll(separators) { separator =>
           val parser = CSVParser.config.fieldDelimiter(separator).fieldSizeLimit(maxFieldSize).get[IO]
-          val input = reader(generateErroneousCSV(testCase, separator))
+          val input = reader[IO].read(generateErroneousCSV(testCase, separator))
           val stream = input.through(parser.parse)
           val ex = intercept[Exception] {
             stream.compile.drain.unsafeRunSync()
@@ -162,7 +162,7 @@ class CSVParserTS extends AnyFunSuite with TableDrivenPropertyChecks {
       forAll(separators) { separator =>
         val parser = CSVParser.config.fieldDelimiter(separator).fieldSizeLimit(maxFieldSize).get[IO]
         val source = Source.fromString(basicCSV(testCase, separator))
-        val input = reader(source)
+        val input = reader[IO].read(source)
         val list = parser.get(input, 2).unsafeRunSync()
         assert(list.size == 2)
         assertListFirst(list, firstName, firstValue)
@@ -211,7 +211,7 @@ class CSVParserTS extends AnyFunSuite with TableDrivenPropertyChecks {
         forAll(separators) { separator =>
           val parser = CSVParser.config.fieldDelimiter(separator).fieldSizeLimit(maxFieldSize).get[IO]
           val source = generateErroneousCSV(testCase, separator)
-          val input = reader(source)
+          val input = reader[IO].read(source)
           val eh: IOErrorHandler = ex => assertError(ex, errorCode, line, col, row, field)(IO.unit)
           parser.process(input)(_ => true).handleErrorWith(eh).unsafeRunSync()
         }
@@ -224,7 +224,7 @@ class CSVParserTS extends AnyFunSuite with TableDrivenPropertyChecks {
       forAll(separators) { separator =>
         val parser = CSVParser.config.fieldDelimiter(separator).fieldSizeLimit(maxFieldSize).get[IO]
         val source = Source.fromString(basicCSV(testCase, separator))
-        val input = reader(source)
+        val input = reader[IO].read(source)
         parser.process(input)(cb).unsafeRunSync()
         assert(source.hasNext)
       }
@@ -271,7 +271,7 @@ class CSVParserTS extends AnyFunSuite with TableDrivenPropertyChecks {
         forAll(separators) { separator =>
           val parser = CSVParser.config.fieldDelimiter(separator).fieldSizeLimit(maxFieldSize).get[IO]
           val source = generateErroneousCSV(testCase, separator)
-          val input = reader(source)
+          val input = reader[IO].read(source)
           val cdl = new CountDownLatch(1)
           var result: Either[Throwable, Unit] = Right(())
           val rcb: Either[Throwable, Unit] => Unit = r => {
@@ -291,7 +291,7 @@ class CSVParserTS extends AnyFunSuite with TableDrivenPropertyChecks {
     }
   }
 
-  private def csvStream(csvString: String) = reader(Source.fromString(csvString))
+  private def csvStream(csvString: String) = reader[IO].read(Source.fromString(csvString))
 
   private def assertListFirst(list: List[CSVRecord], firstName: String, firstValue: String): Unit = {
     val first = list.head

--- a/src/test/scala/info/fingo/spata/io/readerPTS.scala
+++ b/src/test/scala/info/fingo/spata/io/readerPTS.scala
@@ -43,12 +43,12 @@ object readerPTS extends Bench.LocalTime {
   }
 
   private lazy val methods = Gen.enumeration("method")(
-    ReadMethod("source", (path: Path) => bracket(source(path)).through(reader.by)),
-    ReadMethod("source-fs2io", (path: Path) => bracket(source(path)).through(reader.withBlocker.by)),
-    ReadMethod("inputstream", (path: Path) => bracket(inputStream(path)).through(reader.by)),
-    ReadMethod("inputstream-fs2io", (path: Path) => bracket(inputStream(path)).through(reader.withBlocker.by)),
-    ReadMethod("path", (path: Path) => reader.read(path)),
-    ReadMethod("path-fs2io", (path: Path) => reader.withBlocker.read(path))
+    ReadMethod("source", (path: Path) => bracket(source(path)).through(reader[IO].by)),
+    ReadMethod("source-fs2io", (path: Path) => bracket(source(path)).through(reader.shifting[IO].by)),
+    ReadMethod("inputstream", (path: Path) => bracket(inputStream(path)).through(reader[IO].by)),
+    ReadMethod("inputstream-fs2io", (path: Path) => bracket(inputStream(path)).through(reader.shifting[IO].by)),
+    ReadMethod("path", (path: Path) => reader[IO].read(path)),
+    ReadMethod("path-fs2io", (path: Path) => reader.shifting[IO].read(path))
   )
 
   private def inputStream(path: Path) = Files.newInputStream(path, StandardOpenOption.READ)

--- a/src/test/scala/info/fingo/spata/io/readerPTS.scala
+++ b/src/test/scala/info/fingo/spata/io/readerPTS.scala
@@ -22,7 +22,7 @@ object readerPTS extends Bench.LocalTime {
 
   implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
   private val path = Paths.get(getClass.getClassLoader.getResource("mars-weather.csv").toURI)
-  private val parser = CSVParser.config.get // parser with default configuration
+  private val parser = CSVParser.config.get[IO] // parser with default configuration
 
   case class ReadMethod(info: String, method: Path => Stream[IO, Char]) {
     def apply(path: Path): Stream[IO, Char] = method(path)

--- a/src/test/scala/info/fingo/spata/io/readerTS.scala
+++ b/src/test/scala/info/fingo/spata/io/readerTS.scala
@@ -22,15 +22,15 @@ class readerTS extends AnyFunSuite with TableDrivenPropertyChecks {
 
   test("reader should properly load characters from source") {
     forAll(testCases) { (_: String, data: String) =>
-      def stream = reader(Source.fromString(data))
-      stream.zip(reader.read(Source.fromString(data))).map(p => assert(p._1 == p._2)).compile.drain.unsafeRunSync()
+      def stream = reader[IO].read(Source.fromString(data))
+      stream.zip(reader[IO].read(Source.fromString(data))).map(p => assert(p._1 == p._2)).compile.drain.unsafeRunSync()
       assert(stream.compile.toList.unsafeRunSync() == data.toList)
     }
   }
 
   test("reader should allow handling exception with MonadError") {
     val source = new BufferedSource(() => throw new IOException("message"))
-    val stream = reader(source)
+    val stream = reader[IO].read(source)
     val eh = (ex: Throwable) => Stream.emit(ex.isInstanceOf[IOException])
     val result = stream.map(_ => false).handleErrorWith(eh).compile.toList.unsafeRunSync()
     assert(result.length == 1)
@@ -39,8 +39,8 @@ class readerTS extends AnyFunSuite with TableDrivenPropertyChecks {
 
   test("reader should properly load characters from source while shifting IO operations to blocking context") {
     forAll(testCases) { (_: String, data: String) =>
-      def stream = reader.withBlocker.read(Source.fromString(data))
-      stream.zip(reader(Source.fromString(data))).map(p => assert(p._1 == p._2)).compile.drain.unsafeRunSync()
+      def stream = reader.shifting[IO].read(Source.fromString(data))
+      stream.zip(reader[IO].read(Source.fromString(data))).map(p => assert(p._1 == p._2)).compile.drain.unsafeRunSync()
       assert(stream.compile.toList.unsafeRunSync() == data.toList)
     }
   }
@@ -48,7 +48,7 @@ class readerTS extends AnyFunSuite with TableDrivenPropertyChecks {
   test("reader should properly read from InputSteam") {
     forAll(testCases) { (_: String, data: String) =>
       val input = new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8))
-      val stream = reader.read(input)
+      val stream = reader[IO].read(input)
       assert(stream.compile.toList.unsafeRunSync() == data.toList)
     }
   }
@@ -56,21 +56,21 @@ class readerTS extends AnyFunSuite with TableDrivenPropertyChecks {
   test("reader should properly read from InputSteam on blocking context") {
     forAll(testCases) { (_: String, data: String) =>
       val input = new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8))
-      val stream = reader.withBlocker.read(input)
+      val stream = reader.shifting[IO].read(input)
       assert(stream.compile.toList.unsafeRunSync() == data.toList)
     }
   }
 
   test("reader should properly read from path") {
     val path = Paths.get(getClass.getClassLoader.getResource("sample.csv").toURI)
-    val stream = reader.read(path)
+    val stream = reader[IO].read(path)
     val content = stream.compile.toList.unsafeRunSync()
     assert(content.mkString == Files.readString(path))
   }
 
   test("reader should properly read from path using blocking context") {
     val path = Paths.get(getClass.getClassLoader.getResource("sample.csv").toURI)
-    val stream = reader.withBlocker.read(path)
+    val stream = reader.shifting[IO].read(path)
     val content = stream.compile.toList.unsafeRunSync()
     assert(content.mkString == Files.readString(path))
   }
@@ -78,7 +78,7 @@ class readerTS extends AnyFunSuite with TableDrivenPropertyChecks {
   test("reader should properly read UTF-8 files with BOM") {
     val localChar = 'ł'
     val path = Paths.get(getClass.getClassLoader.getResource("bom.csv").toURI)
-    val stream = reader.read(path)
+    val stream = reader[IO].read(path)
     val content = stream.compile.toList.unsafeRunSync()
     assert(content.startsWith("author"))
     assert(content.contains(localChar))
@@ -88,7 +88,7 @@ class readerTS extends AnyFunSuite with TableDrivenPropertyChecks {
     val localChar = 'ł'
     implicit val codec: Codec = new Codec(Charset.forName("windows-1250"))
     val path = Paths.get(getClass.getClassLoader.getResource("windows1250.csv").toURI)
-    val stream = reader.read(path)
+    val stream = reader[IO].read(path)
     val content = stream.compile.toList.unsafeRunSync()
     assert(content.startsWith("author"))
     assert(content.contains(localChar))
@@ -99,7 +99,7 @@ class readerTS extends AnyFunSuite with TableDrivenPropertyChecks {
     implicit val codec: Codec = new Codec(Charset.forName("windows-1250"))
     val path = Paths.get(getClass.getClassLoader.getResource("windows1250.csv").toURI)
     val is = Files.newInputStream(path, StandardOpenOption.READ)
-    val stream = Stream.bracket(IO(is))(resource => IO { resource.close() }).through(reader.withBlocker.by)
+    val stream = Stream.bracket(IO(is))(resource => IO { resource.close() }).through(reader.shifting[IO].by)
     val content = stream.compile.toList.unsafeRunSync()
     assert(content.startsWith("author"))
     assert(content.contains(localChar))
@@ -110,7 +110,7 @@ class readerTS extends AnyFunSuite with TableDrivenPropertyChecks {
     implicit val codec: Codec = new Codec(StandardCharsets.UTF_8)
     val path = Paths.get(getClass.getClassLoader.getResource("windows1250.csv").toURI)
     val is = Files.newInputStream(path, StandardOpenOption.READ)
-    val stream = Stream.bracket(IO(is))(resource => IO { resource.close() }).through(reader.withBlocker.by)
+    val stream = Stream.bracket(IO(is))(resource => IO { resource.close() }).through(reader.shifting[IO].by)
     val content = stream.handleErrorWith(_ => Stream.emit(CAN)).compile.toList.unsafeRunSync()
     assert(content == List(CAN))
   }

--- a/src/test/scala/info/fingo/spata/parser/CharParserTS.scala
+++ b/src/test/scala/info/fingo/spata/parser/CharParserTS.scala
@@ -5,16 +5,17 @@
  */
 package info.fingo.spata.parser
 
+import cats.effect.IO
+import fs2.Stream
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.prop.TableDrivenPropertyChecks
-import fs2.Stream
 import Config._
 import CharStates._
 import CharFailures._
 
 class CharParserTS extends AnyFunSuite with TableDrivenPropertyChecks {
 
-  private val parser = new CharParser(sep, rs, qt)
+  private val parser = new CharParser[IO](sep, rs, qt)
 
   test("Char parser should correctly parse provided input") {
     forAll(regularCases) { (_, input, output) =>

--- a/src/test/scala/info/fingo/spata/parser/FieldParserTS.scala
+++ b/src/test/scala/info/fingo/spata/parser/FieldParserTS.scala
@@ -5,9 +5,10 @@
  */
 package info.fingo.spata.parser
 
+import cats.effect.IO
+import fs2.Stream
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.prop.TableDrivenPropertyChecks
-import fs2.Stream
 import CharParser.CharResult
 import Config._
 import CharStates._
@@ -17,7 +18,7 @@ import FieldFailures._
 
 class FieldParserTS extends AnyFunSuite with TableDrivenPropertyChecks {
 
-  private val parser = new FieldParser(Some(limit))
+  private val parser = new FieldParser[IO](Some(limit))
 
   test("Field parser should correctly parse provided input") {
     forAll(regularCases) { (_, input, output) =>

--- a/src/test/scala/info/fingo/spata/parser/RecordParserTS.scala
+++ b/src/test/scala/info/fingo/spata/parser/RecordParserTS.scala
@@ -5,9 +5,10 @@
  */
 package info.fingo.spata.parser
 
+import cats.effect.IO
+import fs2.Stream
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.prop.TableDrivenPropertyChecks
-import fs2.Stream
 import Config._
 import RawFields._
 import FieldFailures._
@@ -17,7 +18,7 @@ import FieldParser.FieldResult
 
 class RecordParserTS extends AnyFunSuite with TableDrivenPropertyChecks {
 
-  private val parser = new RecordParser()
+  private val parser = new RecordParser[IO]()
 
   test("Record parser should correctly parse provided input") {
     forAll(regularCases) { (_, input, output) =>

--- a/src/test/scala/info/fingo/spata/sample/ConsoleITS.scala
+++ b/src/test/scala/info/fingo/spata/sample/ConsoleITS.scala
@@ -21,7 +21,7 @@ class ConsoleITS extends AnyFunSuite {
 
   test("spata allows manipulate data using stream functionality") {
     case class YT(year: Int, temp: Double) // class to converter data to
-    val parser = CSVParser() // parser with default configuration
+    val parser = CSVParser[IO]() // parser with default configuration and IO effect
     // get stream of CSV records while ensuring source cleanup
     val records = Stream
       .bracket(IO { SampleTH.sourceFromResource(SampleTH.dataFile) })(source => IO { source.close() })
@@ -58,7 +58,7 @@ class ConsoleITS extends AnyFunSuite {
   }
 
   test("spata allows executing simple side effects through callbacks") {
-    val parser = CSVParser.config.get // parser with default configuration
+    val parser = CSVParser.config.get[IO] // parser with default configuration and IO effect
     try {
       SampleTH.withResource(SampleTH.sourceFromResource(SampleTH.dataFile)) { source =>
         parser
@@ -81,7 +81,7 @@ class ConsoleITS extends AnyFunSuite {
   }
 
   test("spata allow processing csv data as list") {
-    val parser = CSVParser() // parser with default configuration
+    val parser = CSVParser[IO]() // parser with default configuration and IO effect
     try {
       SampleTH.withResource(SampleTH.sourceFromResource(SampleTH.dataFile)) { source =>
         // get 500 first records

--- a/src/test/scala/info/fingo/spata/sample/ConsoleITS.scala
+++ b/src/test/scala/info/fingo/spata/sample/ConsoleITS.scala
@@ -25,7 +25,7 @@ class ConsoleITS extends AnyFunSuite {
     // get stream of CSV records while ensuring source cleanup
     val records = Stream
       .bracket(IO { SampleTH.sourceFromResource(SampleTH.dataFile) })(source => IO { source.close() })
-      .through(reader.by)
+      .through(reader[IO].by)
       .through(parser.parse)
     // converter and aggregate data, get stream of YTs
     val aggregates = records.filter { record =>
@@ -62,7 +62,7 @@ class ConsoleITS extends AnyFunSuite {
     try {
       SampleTH.withResource(SampleTH.sourceFromResource(SampleTH.dataFile)) { source =>
         parser
-          .process(reader(source)) { record =>
+          .process(reader[IO].read(source)) { record =>
             if (record.get[Double]("max_temp") > 0) {
               println(s"Maximum daily temperature over 0 degree found on ${record("terrestrial_date")}")
               false
@@ -85,7 +85,7 @@ class ConsoleITS extends AnyFunSuite {
     try {
       SampleTH.withResource(SampleTH.sourceFromResource(SampleTH.dataFile)) { source =>
         // get 500 first records
-        val records = parser.get(reader(source), 500).unsafeRunSync()
+        val records = parser.get(reader[IO].read(source), 500).unsafeRunSync()
         val over0 = records.find(_.get[Double]("max_temp") > 0)
         assert(over0.isDefined)
         for (r <- over0)

--- a/src/test/scala/info/fingo/spata/sample/ConvertITS.scala
+++ b/src/test/scala/info/fingo/spata/sample/ConvertITS.scala
@@ -22,7 +22,7 @@ class ConvertITS extends AnyFunSuite {
     val parser = CSVParser.config.mapHeader(mh).get[IO] // parser with IO effect
     val stream = Stream
       .bracket(IO { SampleTH.sourceFromResource(SampleTH.dataFile) })(source => IO { source.close() }) // ensure resource cleanup
-      .through(reader.by)
+      .through(reader[IO].by)
       .through(parser.parse) // get stream of CSV records
       .map(_.to[DayTemp]()) // converter records to DayTemps
       .rethrow // get data out of Either and let stream fail on error

--- a/src/test/scala/info/fingo/spata/sample/ConvertITS.scala
+++ b/src/test/scala/info/fingo/spata/sample/ConvertITS.scala
@@ -19,7 +19,7 @@ class ConvertITS extends AnyFunSuite {
     // class to converter data to - class fields have to match CSV header fields
     case class DayTemp(date: LocalDate, minTemp: Double, maxTemp: Double)
     val mh = Map("terrestrial_date" -> "date", "min_temp" -> "minTemp", "max_temp" -> "maxTemp")
-    val parser = CSVParser.config.mapHeader(mh).get // parser with default configuration
+    val parser = CSVParser.config.mapHeader(mh).get[IO] // parser with IO effect
     val stream = Stream
       .bracket(IO { SampleTH.sourceFromResource(SampleTH.dataFile) })(source => IO { source.close() }) // ensure resource cleanup
       .through(reader.by)

--- a/src/test/scala/info/fingo/spata/sample/ErrorITS.scala
+++ b/src/test/scala/info/fingo/spata/sample/ErrorITS.scala
@@ -22,7 +22,7 @@ class ErrorITS extends AnyFunSuite with TableDrivenPropertyChecks {
       val parser = CSVParser[IO]()
       val stream = Stream
         .bracket(IO { SampleTH.sourceFromResource(file) })(source => IO { source.close() })
-        .flatMap(reader.read)
+        .flatMap(reader.plain[IO].read)
         .through(parser.parse)
         .map(_.to[Book]())
         .handleErrorWith(ex => Stream.eval(IO(Left(ex)))) // converter global (I/O, CSV structure) errors to Either

--- a/src/test/scala/info/fingo/spata/sample/ErrorITS.scala
+++ b/src/test/scala/info/fingo/spata/sample/ErrorITS.scala
@@ -8,10 +8,10 @@ package info.fingo.spata.sample
 import java.io.IOException
 import cats.effect.IO
 import fs2.Stream
-import info.fingo.spata.io.reader
-import info.fingo.spata.{CSVException, CSVParser}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.prop.TableDrivenPropertyChecks
+import info.fingo.spata.io.reader
+import info.fingo.spata.{CSVException, CSVParser}
 
 class ErrorITS extends AnyFunSuite with TableDrivenPropertyChecks {
 
@@ -19,7 +19,7 @@ class ErrorITS extends AnyFunSuite with TableDrivenPropertyChecks {
 
   test("spata allows consistently handling errors") {
     forAll(files) { (testCase: String, file: String, row: Int) =>
-      val parser = CSVParser()
+      val parser = CSVParser[IO]()
       val stream = Stream
         .bracket(IO { SampleTH.sourceFromResource(file) })(source => IO { source.close() })
         .flatMap(reader.read)

--- a/src/test/scala/info/fingo/spata/sample/FileITS.scala
+++ b/src/test/scala/info/fingo/spata/sample/FileITS.scala
@@ -21,7 +21,7 @@ class FileITS extends AnyFunSuite {
     // get stream of CSV records while ensuring source cleanup
     val records = Stream
       .bracket(IO { SampleTH.sourceFromResource(SampleTH.dataFile) })(source => IO { source.close() })
-      .through(reader.by)
+      .through(reader[IO].by)
       .through(parser.parse)
     // converter and aggregate data, get stream of YTs
     val dtvs = records.filter { record =>
@@ -62,7 +62,8 @@ class FileITS extends AnyFunSuite {
       // get stream of CSV records while ensuring source cleanup
       source <- Stream.bracket(IO { SampleTH.sourceFromResource(SampleTH.dataFile) })(source => IO { source.close() })
       writer <- Stream.bracket(IO { new FileWriter(outFile) })(writer => IO { writer.close() })
-      record <- reader(source)
+      record <- reader[IO]
+        .read(source)
         .through(parser.parse)
         .filter { record =>
           record("max_temp") != "NaN" && record("min_temp") != "NaN"

--- a/src/test/scala/info/fingo/spata/sample/FileITS.scala
+++ b/src/test/scala/info/fingo/spata/sample/FileITS.scala
@@ -17,7 +17,7 @@ class FileITS extends AnyFunSuite {
 
   test("spata allows data conversion to another file") {
     case class DTV(day: String, tempVar: Double) // diurnal temperature variation
-    val parser = CSVParser() // parser with default configuration
+    val parser = CSVParser[IO]() // parser with default configuration and IO effect
     // get stream of CSV records while ensuring source cleanup
     val records = Stream
       .bracket(IO { SampleTH.sourceFromResource(SampleTH.dataFile) })(source => IO { source.close() })
@@ -56,7 +56,7 @@ class FileITS extends AnyFunSuite {
 
   test("spata allows data conversion to another file using for comprehension") {
     case class DTV(day: String, tempVar: Double) // diurnal temperature variation
-    val parser = CSVParser.config.get // parser with default configuration
+    val parser = CSVParser.config.get[IO] // parser with default configuration and IO effect
     val outFile = SampleTH.getTempFile
     val outcome = for {
       // get stream of CSV records while ensuring source cleanup

--- a/src/test/scala/info/fingo/spata/sample/ThreadITS.scala
+++ b/src/test/scala/info/fingo/spata/sample/ThreadITS.scala
@@ -11,10 +11,10 @@ import java.util.concurrent.atomic.LongAdder
 import scala.concurrent.ExecutionContext
 import cats.effect.{Blocker, ContextShift, IO}
 import fs2.Stream
+import org.scalatest.funsuite.AnyFunSuite
 import info.fingo.spata.CSVParser
 import info.fingo.spata.CSVParser.CSVCallback
 import info.fingo.spata.io.reader
-import org.scalatest.funsuite.AnyFunSuite
 
 /* Samples which process the data asynchronously or using blocking context */
 class ThreadITS extends AnyFunSuite {
@@ -23,7 +23,7 @@ class ThreadITS extends AnyFunSuite {
   private def println(s: String): String = s // do nothing, don't pollute test output
 
   test("spata allows asynchronous source processing") {
-    val parser = CSVParser()
+    val parser = CSVParser[IO]()
     val sum = new LongAdder()
     val count = new LongAdder()
 
@@ -55,7 +55,7 @@ class ThreadITS extends AnyFunSuite {
     // class to converter data to - class fields have to match CSV header fields
     case class DayTemp(date: LocalDate, minTemp: Double, maxTemp: Double)
     val mh = Map("terrestrial_date" -> "date", "min_temp" -> "minTemp", "max_temp" -> "maxTemp")
-    val parser = CSVParser.config.mapHeader(mh).get // parser with default configuration
+    val parser = CSVParser.config.mapHeader(mh).get[IO] // parser with IO effect
     val records = for {
       blocker <- Stream.resource(Blocker[IO]) // ensure creation and cleanup of blocking execution context
       // ensure resource allocation and  cleanup

--- a/src/test/scala/info/fingo/spata/sample/ThreadITS.scala
+++ b/src/test/scala/info/fingo/spata/sample/ThreadITS.scala
@@ -43,7 +43,7 @@ class ThreadITS extends AnyFunSuite {
         cdl.countDown()
     }
     SampleTH.withResource(SampleTH.sourceFromResource(SampleTH.dataFile)) { source =>
-      val data = reader.withBlocker.read(source)
+      val data = reader.shifting[IO].read(source)
       parser.async.process(data)(cb).unsafeRunAsync(result)
       assert(sum.intValue() < 1000)
       cdl.await(3, TimeUnit.SECONDS)
@@ -60,7 +60,7 @@ class ThreadITS extends AnyFunSuite {
       blocker <- Stream.resource(Blocker[IO]) // ensure creation and cleanup of blocking execution context
       // ensure resource allocation and  cleanup
       source <- Stream.bracket(IO { SampleTH.sourceFromResource(SampleTH.dataFile) })(source => IO { source.close() })
-      record <- reader.withBlocker(blocker).read(source).through(parser.parse) // get stream of CSV records
+      record <- reader.shifting[IO](blocker).read(source).through(parser.parse) // get stream of CSV records
     } yield record
     val dayTemps = records
       .map(_.to[DayTemp]()) // converter records to DayTemps


### PR DESCRIPTION
Replace cats.effect.IO concrete effect implementation with generic one using tagless final encoding.